### PR TITLE
fix for workspace folder on windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,5 +67,5 @@ function getWorkspaceFolder(): Folder {
     );
   }
 
-  return new Folder(workspaceFolders[0].uri.path);
+  return new Folder(workspaceFolders[0].uri.fsPath);
 }


### PR DESCRIPTION
This fixes the windows file path issue. It is currently untested on mac/linux.

https://github.com/nicoespeon/vscode-slides/issues/1