### PR TITLE
Write and read settings using node's fs

### DIFF
--- a/src/domain.test.ts
+++ b/src/domain.test.ts
@@ -274,10 +274,10 @@ class FakeEditor implements Editor {
   async hideSideBar() {}
   async showSideBar() {}
 
-  async getSettings() {
+  getSettings() {
     return this.settings;
   }
-  async setSettings(settings: Settings) {
+  setSettings(settings: Settings) {
     this.settings = settings;
   }
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -41,7 +41,7 @@ async function restoreSettings(editor: Editor, repository: Repository) {
   const { settings } = await repository.get();
 
   if (settings) {
-    await editor.setSettings(settings);
+    editor.setSettings(settings);
   }
 }
 
@@ -68,9 +68,10 @@ async function start(editor: Editor, repository: Repository) {
 
 async function setSlidesSettings(editor: Editor, repository: Repository) {
   await repository.store({
-    settings: await editor.getSettings()
+    settings: editor.getSettings()
   });
-  await editor.setSettings(getSlidesSettings(editor));
+
+  editor.setSettings(getSlidesSettings(editor));
 }
 
 import { settings as defaults } from "./settings";
@@ -96,8 +97,8 @@ interface Editor {
   openNextFile(): Promise<void>;
   hideSideBar(): Promise<void>;
   showSideBar(): Promise<void>;
-  getSettings(): Promise<Settings | null>;
-  setSettings(settings: Settings): Promise<void>;
+  getSettings(): Settings | null;
+  setSettings(settings: Settings): void;
   showError(message: string): void;
   showMessage(message: string): void;
   getConfiguration(): Configuration;


### PR DESCRIPTION
First of all, thank you for the extension!

After installing it for the first time I was experiencing the same issues described in the linked tickets.

By refactoring the `getSettings` and `setSettings` methods it solves the issues.

### Screencap
![vscode-slides](https://user-images.githubusercontent.com/968014/209491807-e082caed-7452-4d12-ad76-1fe5d6deaee2.gif)

Fixes #15 
Fixes #19 